### PR TITLE
feat: endpoint for mods to retrieve assigned submissions

### DIFF
--- a/api/utils/paginated_response.py
+++ b/api/utils/paginated_response.py
@@ -1,0 +1,79 @@
+from typing import Any, Dict, List, Optional
+from fastapi.encoders import jsonable_encoder
+from sqlalchemy.orm import Session
+from api.db.database import Base
+
+from api.utils.success_response import success_response
+
+
+def paginated_response(
+    db: Session,
+    model,
+    skip: int,
+    limit: int,
+    filters: Optional[Dict[str, Any]] = None,
+) -> dict[str]:
+    """
+    Custom response for pagination.\n
+    This takes in four arguments:
+        * db- this is the database session
+        * model- this is the database table model eg Product, Organisation```
+        * limit- this is the number of items to fetch per page, this would be a query parameter
+        * skip- this is the number of items to skip before fetching the next page of data. This would also
+        be a query parameter
+        * filters- this is an optional dictionary of filters to apply to the query
+
+    Example use:
+        **Without filter**
+        ``` python
+        return paginated_response(
+            db=db,
+            model=Product,
+            limit=limit,
+            skip=skip
+        )
+        ```
+
+        **With filter**
+        ``` python
+        return paginated_response(
+            db=db,
+            model=Product,
+            limit=limit,
+            skip=skip,
+            filters={'org_id': org_id}
+        )
+        ```
+    """
+
+    query = db.query(model)
+
+    if filters:
+        # Apply filters
+        for attr, value in filters.items():
+            if value is not None:
+                column = getattr(model, attr)
+                if isinstance(column.type, str):
+                    # Handle string fields
+                    query = query.filter(column.like(f"%{value}%"))
+                else:
+                    # Handle other types (e.g., Integer, DateTime, Boolean)
+                    query = query.filter(column == value)
+
+    total = query.count()
+    results = query.order_by(model.created_at.desc()).offset(skip).limit(limit).all()
+
+    # items = jsonable_encoder(results)
+    try:
+        total_pages = int(total / limit) + (total % limit > 0)
+    except:
+        total_pages = int(total / limit)
+
+    paginated_data = {
+        "total_pages": total_pages,
+        "total": total,
+        "skip": skip,
+        "limit": limit,
+        "results": results,
+    }
+    return paginated_data

--- a/api/utils/responses.py
+++ b/api/utils/responses.py
@@ -1,0 +1,14 @@
+from pydantic import BaseModel
+
+
+class BaseErrResponseModel(BaseModel):
+    success: bool = False
+    message: str
+
+
+class Regular401Response(BaseErrResponseModel):
+    status_code: int = 401
+
+
+class Regular500Response(BaseErrResponseModel):
+    status_code: int = 500

--- a/api/v1/models/trivia.py
+++ b/api/v1/models/trivia.py
@@ -8,12 +8,7 @@ from api.v1.models.association import (
     category_trivia_association,
 )
 from api.v1.models.base_model import BaseTableModel
-
-
-class DifficultyEnum(str, enum.Enum):
-    easy = "easy"
-    medium = "medium"
-    hard = "hard"
+from api.v1.schemas.submission import DifficultyEnum
 
 
 class Trivia(BaseTableModel):

--- a/api/v1/routes/__init__.py
+++ b/api/v1/routes/__init__.py
@@ -1,10 +1,11 @@
 from fastapi import APIRouter
-from api.v1.routes.submission import submissions
+from api.v1.routes.submission import submissions, assigned_submissions
 from api.v1.routes.auth import auth
 from api.v1.routes.moderator import moderator
 
 api_version_one = APIRouter(prefix="/api/v1")
 
 api_version_one.include_router(submissions)
+api_version_one.include_router(assigned_submissions)
 api_version_one.include_router(auth)
 api_version_one.include_router(moderator)

--- a/api/v1/routes/submission.py
+++ b/api/v1/routes/submission.py
@@ -1,23 +1,28 @@
-
-from fastapi import APIRouter, Depends, status
+from fastapi import APIRouter, Depends, status, Query
 from fastapi.encoders import jsonable_encoder
 from sqlalchemy.orm import Session
+from typing import Annotated, Literal
 
 from api.db.database import get_db
 from api.utils.success_response import success_response
-from api.v1.schemas.submission import CreateSubmissionSchema, PostSubmissionResponseSchema, PostSubmissionResponseModelSchema
+from api.v1.schemas.submission import (
+    CreateSubmissionSchema,
+    PostSubmissionResponseSchema,
+    PostSubmissionResponseModelSchema,
+    PaginatedResponseModelSchema,
+)
+from api.v1.services.moderator import mod_service, Moderator
 from api.v1.services.submission import submission_service
 from api.utils.logger import logger
+from api.utils import responses
 
-submissions = APIRouter(prefix='/submissions', tags=['Submissions'])
+submissions = APIRouter(prefix="/submissions", tags=["Submissions"])
 
-@submissions.post("",
-                  response_model=PostSubmissionResponseModelSchema,
-                  status_code=201)
+
+@submissions.post("", response_model=PostSubmissionResponseModelSchema, status_code=201)
 async def create_submission(
-    schema: CreateSubmissionSchema,
-    db: Session = Depends(get_db)
-    ):
+    schema: CreateSubmissionSchema, db: Session = Depends(get_db)
+):
     """Endpoint to create a new submission.
 
     Args:
@@ -28,10 +33,41 @@ async def create_submission(
     """
     submission = submission_service.create(db, schema=schema)
     s_dict = submission.to_dict()
-    
-    logger.info(f'Created new submission. ID: {submission.id}.')
+
+    logger.info(f"Created new submission. ID: {submission.id}.")
     return success_response(
         data=jsonable_encoder(PostSubmissionResponseSchema.model_validate(s_dict)),
         message="Successfully added submission",
         status_code=status.HTTP_201_CREATED,
+    )
+
+
+@submissions.get("", response_model=PaginatedResponseModelSchema, status_code=200)
+async def retrieve_submission_for_mods(
+    status: Literal["pending", "approved", "rejected"] | None = None,
+    page: Annotated[int | None, Query(gt=0)] = 1,
+    limit: Annotated[int | None, Query(gt=0)] = 5,
+    db: Session = Depends(get_db),
+    current_mod: Moderator = Depends(mod_service.get_current_mod),
+):
+    """This function retrieves submissions assigned to a particular moderator\n
+
+    Args:\n
+        status (Literal['pending', 'approved', 'rejected'] | None, optional): The kind of submissions to be retrieved. If None, retrieve all submissions. Defaults to None.\n
+        page (Annotated[int  |  None, Query, optional): The page to be retrieved. Defaults to 0)]=1.\n
+        limit (Annotated[int  |  None, Query, optional): The number of items per page. Defaults to 0)]=5.\n
+        db (Session): The db session.\n
+        current_mod (Moderator): Mod making the request.
+    """
+    filter_obj = {"moderator_id": current_mod.id, "status": status}
+
+    # Naturally page numbers start from 1. On the db we calculate skip(items to skip over) from 0
+    skip = (page - 1) * limit
+
+    paged_res = submission_service.fetch_paginated(
+        db=db, skip=skip, limit=limit, filters=filter_obj
+    )
+
+    return success_response(
+        status_code=200, message="Submissions retrieved successfully", data=paged_res
     )

--- a/api/v1/routes/submission.py
+++ b/api/v1/routes/submission.py
@@ -16,6 +16,7 @@ from api.v1.services.submission import submission_service
 from api.utils.logger import logger
 from api.utils import responses
 
+assigned_submissions = APIRouter(prefix="/assigned-submissions", tags=["Submissions"])
 submissions = APIRouter(prefix="/submissions", tags=["Submissions"])
 
 
@@ -42,7 +43,9 @@ async def create_submission(
     )
 
 
-@submissions.get("", response_model=PaginatedResponseModelSchema, status_code=200)
+@assigned_submissions.get(
+    "", response_model=PaginatedResponseModelSchema, status_code=200
+)
 async def retrieve_submission_for_mods(
     status: Literal["pending", "approved", "rejected"] | None = None,
     page: Annotated[int | None, Query(gt=0)] = 1,
@@ -50,7 +53,7 @@ async def retrieve_submission_for_mods(
     db: Session = Depends(get_db),
     current_mod: Moderator = Depends(mod_service.get_current_mod),
 ):
-    """This function retrieves submissions assigned to a particular moderator\n
+    """Endpoint to retrieves submissions assigned to a particular moderator\n
 
     Args:\n
         status (Literal['pending', 'approved', 'rejected'] | None, optional): The kind of submissions to be retrieved. If None, retrieve all submissions. Defaults to None.\n

--- a/api/v1/schemas/submission.py
+++ b/api/v1/schemas/submission.py
@@ -46,13 +46,30 @@ class CreateSubmissionSchema(SubmissionBaseSchema):
     countries: list[ACE] = Field(default=[])
 
 
-class PostSubmissionResponseSchema(SubmissionBaseSchema):
+class HelperResponseSchemaOne(CreateSubmissionSchema):
     id: str
     status: str
+    created_at: datetime
+
+
+class PostSubmissionResponseSchema(HelperResponseSchemaOne, SubmissionBaseSchema):
     moderator_id: str
-    updated_at: datetime
-    category: CategoryEnum
-    countries: list[ACE] = Field(default=[])
+
+
+class RetrieveSubmissionForModSchema(HelperResponseSchemaOne, SubmissionBaseSchema):
+    pass
+
+
+class PaginatedBaseSchema(BaseModel):
+    page: int
+    total_pages: int
+    total: int
+    limit: int
+    items: list[RetrieveSubmissionForModSchema]
+
+
+class PaginatedResponseModelSchema(BaseSuccessResponseSchema):
+    data: PaginatedBaseSchema
 
 
 class PostSubmissionResponseModelSchema(BaseSuccessResponseSchema):

--- a/api/v1/services/moderator.py
+++ b/api/v1/services/moderator.py
@@ -43,6 +43,12 @@ class ModeratorService(Service):
         detail="Moderator not found",
     )
 
+    CREDENTIALS_EXC = HTTPException(
+        status_code=401,
+        detail="Could not validate credentials",
+        headers={"WWW-Authenticate": "Bearer"},
+    )
+
     def fetch_all():
         pass
 
@@ -346,6 +352,9 @@ class ModeratorService(Service):
             detail="Could not validate credentials",
             headers={"WWW-Authenticate": "Bearer"},
         )
+
+        if credentials is None:
+            raise credentials_exception
 
         mod_id = self.verify_access_token(
             credentials.credentials, credentials_exception

--- a/api/v1/services/submission.py
+++ b/api/v1/services/submission.py
@@ -2,6 +2,7 @@ from sqlalchemy.orm import Session
 from sqlalchemy.exc import IntegrityError
 from fastapi import HTTPException
 
+from api.utils.paginated_response import paginated_response
 from api.v1.models.submission import Submission, SubmissionOption
 from api.core.base.services import Service
 from api.v1.schemas import submission as s_schema
@@ -13,8 +14,6 @@ from api.v1.models.country import Country
 from api.v1.models.category import Category
 from api.utils.logger import logger
 from api.utils.sql_queries import query_for_mods_pref_submissions
-
-
 
 
 class SubmissionService(Service):
@@ -33,16 +32,12 @@ class SubmissionService(Service):
     def fetch_all():
         pass
 
-
-
     def fetch(self, db: Session, id: str):
         pass
 
-    def extract_countries_categories_options(self, schema_d: dict,
-                                             db: Session) -> tuple[list[Country], 
-                                                                  list[Category],
-                                                                  list[SubmissionOption]]:
-        
+    def extract_countries_categories_options(
+        self, schema_d: dict, db: Session
+    ) -> tuple[list[Country], list[Category], list[SubmissionOption]]:
         """This method extracts and converts countries, categories and options
             present in the schema dump into sqlalchemy models
 
@@ -52,30 +47,33 @@ class SubmissionService(Service):
         Returns:
             tuple: A tuple containing a list of extracted models (countries, categories and options)
         """
-        try: 
-            countries = schema_d.pop('countries', [])
+        try:
+            countries = schema_d.pop("countries", [])
             country_models_list = CountryService.fetch_countries(db, countries)
 
-            given_category = schema_d.pop('category')
-            category_models_list = CategoryService.fetch_categories(db, [given_category])
+            given_category = schema_d.pop("category")
+            category_models_list = CategoryService.fetch_categories(
+                db, [given_category]
+            )
 
-            all_options = schema_d.pop('incorrect_options')
-            all_options.append(schema_d.pop('correct_option'))
+            all_options = schema_d.pop("incorrect_options")
+            all_options.append(schema_d.pop("correct_option"))
 
             options_models_list = [
                 SubmissionOption(content=all_options[0]),
                 SubmissionOption(content=all_options[1]),
                 SubmissionOption(content=all_options[2]),
                 SubmissionOption(content=all_options[3], is_correct=True),
-            ]    
+            ]
 
             return (country_models_list, category_models_list, options_models_list)
-        
+
         except Exception as e:
             logger.exception(e)
 
-    def create(self, db: Session,
-               schema: s_schema.CreateSubmissionSchema) -> Submission:
+    def create(
+        self, db: Session, schema: s_schema.CreateSubmissionSchema
+    ) -> Submission:
         """Creates a new submission
 
 
@@ -88,17 +86,17 @@ class SubmissionService(Service):
         """
         try:
             schema_dump = schema.model_dump()
-            assoc_countries_copy = schema_dump.get('countries', []).copy()
+            assoc_countries_copy = schema_dump.get("countries", []).copy()
 
-            [country_models_list, category_models_list, options_models_list] =\
+            [country_models_list, category_models_list, options_models_list] = (
                 self.extract_countries_categories_options(schema_dump, db)
+            )
 
             sub = Submission(**schema_dump)
             sub.countries = country_models_list
             sub.categories = category_models_list
             sub.options = options_models_list
 
-            
             mod_id = self.find_suitable_mod(db, assoc_countries_copy)
             sub.moderator_id = mod_id
 
@@ -107,17 +105,16 @@ class SubmissionService(Service):
             db.refresh(sub)
 
             return sub
-    
+
         except IntegrityError as e:
             raise HTTPException(
                 status_code=400,
                 detail="This question already exists",
-        )
+            )
 
         except Exception as e:
             logger.exception(e)
 
-    
     def get_mod_prefs_and_assigns(self, db: Session) -> list[tuple[str, list, int]]:
         """This function uses sql queries to retrieve details of moderators
         present on the database. These details are used to determine what mod
@@ -138,7 +135,7 @@ class SubmissionService(Service):
         except Exception as e:
             logger.exception(e)
 
-    def find_suitable_mod(self, db:Session, assoc_countries: list) -> str:
+    def find_suitable_mod(self, db: Session, assoc_countries: list) -> str:
         """Function to detetmin what moderator is suitable to be assigned
         for a given submission made to the db.
 
@@ -156,12 +153,40 @@ class SubmissionService(Service):
                 # with lowest pending assigns
                 return all_mod_details[0][0]
 
-            for (mod_id, mod_cntry_pref, pending_count) in all_mod_details:
-                if len(mod_cntry_pref) == 0 or\
-                    set(mod_cntry_pref).intersection(assoc_countries):
+            for mod_id, mod_cntry_pref, pending_count in all_mod_details:
+                if len(mod_cntry_pref) == 0 or set(mod_cntry_pref).intersection(
+                    assoc_countries
+                ):
                     return mod_id
-        
+
         except Exception as e:
             logger.exception(e)
+
+    def fetch_paginated(
+        self, db: Session, skip: int, limit: int, filters: dict[str]
+    ) -> dict[str]:
+
+        page_number = int(skip / limit) + 1
+
+        resp = paginated_response(
+            db=db, model=Submission, skip=skip, limit=limit, filters=filters
+        )
+
+        resp.pop("skip", None)
+        resp["page"] = page_number
+
+        resp["items"] = list(
+            map(
+                lambda x: s_schema.RetrieveSubmissionForModSchema.model_validate(
+                    x.to_dict()
+                ),
+                resp["results"],
+            )
+        )
+
+        resp.pop("results", None)
+
+        return resp
+
 
 submission_service = SubmissionService()

--- a/tests/v1/submission/test_retrieve_paginated_assigned_submission.py
+++ b/tests/v1/submission/test_retrieve_paginated_assigned_submission.py
@@ -1,0 +1,140 @@
+from unittest.mock import MagicMock
+from pytest_mock import MockerFixture
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from api.db.database import get_db
+from api.v1.routes.submission import mod_service
+from api.v1.services.submission import submission_service
+from main import app
+
+
+
+db_session_mock = MagicMock(spec=Session)
+
+
+def db_session_mock_fn():
+    yield db_session_mock
+
+
+client = TestClient(app)
+
+
+ENDPOINT = "/api/v1/assigned-submissions"
+
+
+class TestRetrieveSubmissionForMods:
+
+    @classmethod
+    def setup_class(cls):
+        app.dependency_overrides[get_db] = db_session_mock_fn
+        app.dependency_overrides[mod_service.get_current_mod] = lambda: MagicMock(
+            id="mod_id"
+        )
+        pass
+
+    @classmethod
+    def teardown_class(cls):
+        app.dependency_overrides = {}
+
+    # Retrieve all submissions for a moderator with default pagination
+    def test_retrieve_all_submissions_default_pagination(self, mocker: MockerFixture):
+
+        mock_obj = mocker.patch.object(
+            submission_service, "fetch_paginated", return_value=[]
+        )
+
+        response = client.get(ENDPOINT)
+        assert response.status_code == 200
+
+        mock_obj.assert_called_once_with(
+            db=db_session_mock,
+            skip=0,
+            limit=5,
+            filters={"moderator_id": "mod_id", "status": None},
+        )
+
+    # Retrieve submissions with a specific status for a moderator
+    def test_retrieve_submissions_specific_status(self, mocker):
+        mock_obj = mocker.patch.object(
+            submission_service, "fetch_paginated", return_value=[]
+        )
+
+        response = client.get(f"{ENDPOINT}?status=approved")
+        assert response.status_code == 200
+
+        mock_obj.assert_called_once_with(
+            db=db_session_mock,
+            skip=0,
+            limit=5,
+            filters={"moderator_id": "mod_id", "status": "approved"},
+        )
+
+        assert response.json()["message"] == "Submissions retrieved successfully"
+        assert response.json()["data"] == []
+
+    # Retrieve submissions with custom page and limit values
+    def test_retrieve_submissions_custom_page_limit(self, mocker):
+
+        mock_obj = mocker.patch.object(
+            submission_service, "fetch_paginated", return_value=[]
+        )
+
+        response = client.get(f"{ENDPOINT}?status=approved&page=2")
+        assert response.status_code == 200
+
+        mock_obj.assert_called_once_with(
+            db=db_session_mock,
+            skip=5,
+            limit=5,
+            filters={"moderator_id": "mod_id", "status": "approved"},
+        )
+
+        assert response.json()["message"] == "Submissions retrieved successfully"
+        assert response.json()["data"] == []
+
+    # Correctly calculated skip value based on page and limit
+    def test_correct_skip_value_calculation(self, mocker):
+
+        mock_obj = mocker.patch.object(
+            submission_service, "fetch_paginated", return_value=[]
+        )
+
+        response = client.get(f"{ENDPOINT}?status=pending&page=3&limit=10")
+        assert response.status_code == 200
+
+        mock_obj.assert_called_once_with(
+            db=db_session_mock,
+            skip=20,
+            limit=10,
+            filters={"moderator_id": "mod_id", "status": "pending"},
+        )
+
+        assert response.json()["message"] == "Submissions retrieved successfully"
+        assert response.json()["data"] == []
+
+    # Retrieve submissions with an invalid status value
+    def test_retrieve_submissions_invalid_status(self):
+        response = client.get(f"{ENDPOINT}?status=what&page=3&limit=10")
+        assert response.status_code == 422
+        assert "errors" in response.json()
+
+    # Retrieve submissions with page number less than 1
+    def test_retrieve_submissions_page_number_less_than_1(self):
+        response = client.get(f"{ENDPOINT}?status=pending&page=0&limit=10")
+        assert response.status_code == 422
+        assert "errors" in response.json()
+
+    # Retrieve submissions with limit value less than 1
+    def test_retrieve_submissions_limit_less_than_1(self):
+        response = client.get(f"{ENDPOINT}?status=pending&page=1&limit=0")
+        assert response.status_code == 422
+        assert "errors" in response.json()
+
+    # Ensure the moderator is authenticated before retrieving submissions
+    def test_moderator_authentication_required(self):
+        app.dependency_overrides = {}
+
+        response = client.get(f"{ENDPOINT}")
+        assert response.status_code == 401
+        assert response.json()["message"] == "Could not validate credentials"

--- a/tests/v1/submission/test_retrieve_paginated_submission.py
+++ b/tests/v1/submission/test_retrieve_paginated_submission.py
@@ -1,0 +1,149 @@
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+from pytest_mock import MockerFixture
+from fastapi.testclient import TestClient
+from fastapi import HTTPException
+from sqlalchemy.orm import Session
+from sqlalchemy.exc import IntegrityError
+from uuid_extensions import uuid7
+
+from api.db.database import get_db
+from api.v1.routes.submission import mod_service
+from api.v1.services.submission import submission_service
+from api.v1.models.submission import Submission, SubmissionOption
+from api.v1.models.category import Category
+from api.v1.models.country import Country
+from main import app
+
+
+def mock_submission():
+    return Submission(
+        id=str(uuid7()),
+        question="Who is the first Algerian President?",
+        status="Pending",
+        difficulty="easy",
+        moderator_id="some_mod",
+        created_at=datetime.now(timezone.utc),
+        updated_at=datetime.now(timezone.utc),
+    )
+
+
+db_session_mock = MagicMock(spec=Session)
+
+
+def db_session_mock_fn():
+    yield db_session_mock
+
+
+client = TestClient(app)
+
+
+mock_db_store = [
+    {
+        "question": "In what year was the African Union established?",
+        "incorrect_options": ["2005", "1993", "1999"],
+        "correct_option": "2001",
+        "difficulty": "easy",
+        "submission_note": None,
+        "category": "General Knowledge",
+        "countries": [],
+        "id": "066dfa7d-f307-7974-8000-a3ee98a563f3",
+        "status": "pending",
+        "created_at": "2024-09-10T02:58:55.149655+01:00",
+    },
+    {
+        "question": "Who is the current president of Algeria?",
+        "incorrect_options": ["Lil Wayne", "George Bush", "Barack Obama"],
+        "correct_option": "Abdelmadjid Tebboune",
+        "difficulty": "easy",
+        "submission_note": None,
+        "category": "General Knowledge",
+        "countries": ["Algeria"],
+        "id": "066dfa4f-de25-7b53-8000-6730fbe651bf",
+        "status": "pending",
+        "created_at": "2024-09-10T02:46:37.863201+01:00",
+    },
+    {
+        "question": "Whose face is present on the five hundred naira note?",
+        "incorrect_options": ["Tinubu", "Kamala", "Harrison"],
+        "correct_option": "Nnamdi Azikiwe",
+        "difficulty": "easy",
+        "submission_note": None,
+        "category": "General Knowledge",
+        "countries": ["Nigeria"],
+        "id": "066dfa48-83c8-7c0d-8000-1857173fd0d5",
+        "status": "rejected",
+        "created_at": "2024-09-10T02:44:40.194681+01:00",
+    },
+    {
+        "question": "Whose face is present on the ten naira note?",
+        "incorrect_options": ["Trump", "Icheke", "Obi"],
+        "correct_option": "Alvan Ikoku",
+        "difficulty": "easy",
+        "submission_note": None,
+        "category": "General Knowledge",
+        "countries": ["Nigeria"],
+        "id": "066dfa22-e281-7d82-8000-b80215b771f0",
+        "status": "rejected",
+        "created_at": "2024-09-10T02:34:38.125340+01:00",
+    },
+    {
+        "question": "Who is the present governor of Lagos?",
+        "incorrect_options": ["Pavlov", "Durov", "Emenike"],
+        "correct_option": "Sanwo Olu",
+        "difficulty": "easy",
+        "submission_note": None,
+        "category": "General Knowledge",
+        "countries": ["Nigeria"],
+        "id": "066dfa0d-9d61-7748-8000-b4e4ec4bd938",
+        "status": "approved",
+        "created_at": "2024-09-10T02:28:57.806201+01:00",
+    },
+    {
+        "question": "Who is the former governor of Lagos?",
+        "incorrect_options": ["Pavlov", "Durov", "Emenike"],
+        "correct_option": "Ambode",
+        "difficulty": "easy",
+        "submission_note": None,
+        "category": "General Knowledge",
+        "countries": ["Nigeria"],
+        "id": "066dfa0a-d2e9-743d-8000-5d9a086d1d5e",
+        "status": "approved",
+        "created_at": "2024-09-10T02:28:13.134585+01:00",
+    },
+]
+
+
+ENDPOINT = "/api/v1/submissions"
+
+
+class TestRetrieveSubmissionForMods:
+
+    @classmethod
+    def setup_class(cls):
+        app.dependency_overrides[get_db] = db_session_mock_fn
+        app.dependency_overrides[mod_service.get_current_mod] = lambda: MagicMock(
+            id="mod_id"
+        )
+        pass
+
+    @classmethod
+    def teardown_class(cls):
+        app.dependency_overrides = {}
+
+    # Retrieve all submissions for a moderator with default pagination
+    def test_retrieve_all_submissions_default_pagination(self, mocker: MockerFixture):
+
+        with patch.object(
+            submission_service, "fetch_paginated", return_value=[]
+        ) as mock_obj:
+
+            response = client.get(ENDPOINT)
+            assert response.status_code == 200
+            mock_obj.assert_called_once_with(
+                db=db_session_mock,
+                skip=0,
+                limit=5,
+                filters={"moderator_id": "mod_id", "status": None},
+            )


### PR DESCRIPTION
## Description

Created an API endpoint `GET /api/v1/assigned-submissions` for the retrieval of assigned submissions by moderators.

This endpoint ensures that moderators can retrieve a paginated response of all submissions assigned to them on the backend.

The changes include:

- **Endpoint Addition:**

  - Added `GET /api/v1/assigned-submissions?status=<string>&limit=5&page=1` for authenticated moderators to get a paginated response of assigned submissions.

    - **status**: If absent, retrieves all assigned submissions. Otherwise can only take values in `['pending', 'approved', 'rejected']`
    - **limit**: The max number of items to be retrieved per page. This value will be used to calculate the skip value on the db. Defaults to 5.
    - **page**: The page number to be retrieved. Defaults to 1.

- **Error Handling:**

  - Implemented checks for invalid query parameters.
  - Implemented unauthorized access checks.

- **Helper Functions:** Added utility functions and service methods to help with pagination process on the backend.

## Motivation and Context

This endpoint is necessary for the moderators to be able to perform thier roles of reviewing the submissions made.

## How Has This Been Tested?

- **Unit Tests:** Tests were present to validate values of query parameters and authentiation of moderator.
- **Test Environment:** Tests were run using a mocked database instance to avoid interference with the dev environment.

Tests include:

- Passing correct query parameter values.
- Authenticated resets

## Screenshots:

### Unauthenticated Request

![image](https://github.com/user-attachments/assets/12399b65-6918-45f6-97ef-aaff9d6badaa)

### Successful request with default query parameter values

![image](https://github.com/user-attachments/assets/80a980fc-b0b1-4321-b4a4-ab40d36f72e8)

### Successfully retrieve `pending` submissions

![image](https://github.com/user-attachments/assets/d2f519e8-ecc8-4494-82eb-2ac516ac6788)

### Successfully retrieve second page with a limit of 2

![image](https://github.com/user-attachments/assets/a3d601dd-2794-4199-a0ac-1edb76d73ce9)

### Successfully retrieve second page of `rejected` submissions with a limit of 2 (Empty items array)

![image](https://github.com/user-attachments/assets/9f62cd7b-acb6-46fb-8391-d434ca8375e9)

### Unsuccessful request due to invalid `status` parameter value

![image](https://github.com/user-attachments/assets/999301db-21ff-4977-8146-3db08d524b89)

### Unsuccessful request due to invalid `page` parameter value

![image](https://github.com/user-attachments/assets/742a8078-704c-4445-9c70-a222728d4e97)

### Unsuccessful request due to invalid `limit` parameter value

![image](https://github.com/user-attachments/assets/e7f3b8a5-9a0e-4bf8-b6b4-d9a0fbf9bd52)

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
