### PR TITLE
feat: Added more endpoints to the /submissions path to aid functionality

### DIFF
--- a/api/utils/sql_queries.py
+++ b/api/utils/sql_queries.py
@@ -54,3 +54,20 @@ def query_for_mods_pref_submissions() -> Select:
     )
 
     return query
+
+
+def query_for_submission_stats() -> Select:
+    """This query gets the number of total, pending, awaiting, approved and
+       rejected submissions in the database
+
+    Returns:
+        Select: SQLAlchemy select statement
+    """
+    query = select(
+        func.count().label("total"),
+        func.count().filter(Submission.status == "pending").label("pending"),
+        func.count().filter(Submission.status == "awaiting").label("awaiting"),
+        func.count().filter(Submission.status == "approved").label("approved"),
+        func.count().filter(Submission.status == "rejected").label("rejected"),
+    )
+    return query

--- a/api/v1/routes/trivia.py
+++ b/api/v1/routes/trivia.py
@@ -129,7 +129,7 @@ async def update_trivia(
     "/{id}",
     status_code=204,
 )
-async def retrieve_single_trivia(
+async def delete_single_trivia(
     id: str,
     db: Session = Depends(get_db),
     mod: Moderator = Depends(mod_service.get_current_admin),

--- a/api/v1/schemas/submission.py
+++ b/api/v1/schemas/submission.py
@@ -84,3 +84,21 @@ class GetSubmissionForModResponseModelSchema(BaseSuccessResponseSchema):
 
 class GetListOfSubmissionForModResponseModelSchema(BaseSuccessResponseSchema):
     data: list[RetrieveSubmissionForModSchema]
+
+
+class GetSubmissionStatsResponseModelSchema(BaseSuccessResponseSchema):
+    class SubmissionStatSchema(BaseModel):
+        total: int
+        pending: int
+        approved: int
+        rejected: int
+
+    data: SubmissionStatSchema
+
+
+class GetListOfCountriesResponseModelSchema(BaseSuccessResponseSchema):
+    data: list[ACE]
+
+
+class GetListOfCategoriesResponseModelSchema(BaseSuccessResponseSchema):
+    data: list[CategoryEnum]

--- a/tests/v1/submission/test_delete_submission.py
+++ b/tests/v1/submission/test_delete_submission.py
@@ -1,0 +1,110 @@
+import pytest
+
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
+from pytest_mock import MockerFixture
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+from api.v1.services.moderator import (
+    bearer_scheme,
+    mod_service,
+    HTTPAuthorizationCredentials,
+)
+
+from api.db.database import get_db
+from api.v1.services.submission import submission_service
+from api.v1.models.submission import Submission
+from main import app
+
+ENDPOINT_URL = "/api/v1/submissions/{}"
+
+
+def mock_sub(question="Who"):
+    subm = Submission(
+        id="some-id",
+        status="pending",
+        question=question,
+        moderator_id="random-mod-id",
+        difficulty="medium",
+        created_at=datetime.now(timezone.utc),
+        updated_at=datetime.now(timezone.utc),
+    )
+
+    return subm
+
+
+mocked_db = MagicMock(spec=Session)
+
+
+def db_session_mock():
+    yield mocked_db
+
+
+@pytest.fixture
+def client():
+    client = TestClient(app)
+    yield client
+
+
+class TestClassDeleteSubmission:
+    @classmethod
+    def setup_class(cls):
+        app.dependency_overrides[get_db] = db_session_mock
+        app.dependency_overrides[mod_service.get_current_admin] = lambda: MagicMock(
+            id="mod_id"
+        )
+
+    @classmethod
+    def teardown_class(cls):
+        app.dependency_overrides = {}
+
+    # Successfully delete submission from the database
+    def test_delete_submission_success(self, client: TestClient, mocker: MockerFixture):
+        mock_s = mock_sub()
+        mock_fetch = mocker.patch.object(
+            submission_service, "delete", return_value=mock_s
+        )
+
+        response = client.delete(ENDPOINT_URL.format("some-id"))
+
+        assert response.status_code == 204
+        mock_fetch.assert_called_once_with(db=mocked_db, id=mock_s.id)
+
+    # Invalid id
+    def test_delete_submission_invalid_id(self, client, mocker):
+
+        mocker.patch.object(mocked_db, "get", return_value=None)
+
+        response = client.delete(ENDPOINT_URL.format("some-id"))
+        assert response.status_code == 404
+        assert response.json()["message"] == "Submission not found"
+
+    # Handling unauthenticated request
+    def test_delete_submission_unauthenticated(self, client):
+        app.dependency_overrides = {}
+
+        response = client.delete(ENDPOINT_URL.format("some-id"))
+        assert response.status_code == 401
+        assert response.json()["message"] == "Could not validate credentials"
+
+    # Handling forbidden request
+    def test_delete_submission_forbidden(self, client, mocker):
+        app.dependency_overrides = {}
+        app.dependency_overrides[get_db] = lambda: mocked_db
+        app.dependency_overrides[bearer_scheme] = lambda: HTTPAuthorizationCredentials(
+            scheme="bearer", credentials="some-token"
+        )
+
+        mocker.patch.object(
+            mod_service,
+            "get_current_mod",
+            return_value=MagicMock(is_admin=False),
+        )
+        response = client.delete(ENDPOINT_URL.format("some-id"))
+        assert response.status_code == 403
+        assert (
+            response.json()["message"]
+            == "You do not have permission to access this resource"
+        )

--- a/tests/v1/submission/test_retrieve_all_submissions.py
+++ b/tests/v1/submission/test_retrieve_all_submissions.py
@@ -1,0 +1,141 @@
+import pytest
+
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
+from pytest_mock import MockerFixture
+
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+from uuid_extensions import uuid7
+
+from api.v1.services.moderator import (
+    bearer_scheme,
+    mod_service,
+    HTTPAuthorizationCredentials,
+)
+from api.db.database import get_db
+from api.v1.services.submission import (
+    submission_service,
+    CountryService,
+    CategoryService,
+)
+from api.v1.models.submission import Submission, SubmissionOption
+from api.v1.models.category import Category
+from api.v1.models.country import Country
+from main import app
+
+ENDPOINT_URL = "/api/v1/submissions"
+
+
+def mock_sub(question="Who"):
+    subm = Submission(
+        id=str(uuid7()),
+        status="pending",
+        question=question,
+        moderator_id="random-mod-id",
+        difficulty="medium",
+        created_at=datetime.now(timezone.utc),
+        updated_at=datetime.now(timezone.utc),
+    )
+    subm.categories = [Category(name="Politics")]
+    subm.countries = [Country(name="Algeria")]
+
+    subm.options = [
+        SubmissionOption(content="Test", is_correct=False),
+        SubmissionOption(content="options", is_correct=False),
+        SubmissionOption(content="for", is_correct=False),
+        SubmissionOption(content="mocked data", is_correct=True),
+    ]
+
+    return subm
+
+
+mocked_db = MagicMock(spec=Session)
+
+
+def db_session_mock():
+    yield mocked_db
+
+
+@pytest.fixture
+def client():
+    client = TestClient(app)
+    yield client
+
+
+class TestRetrieveAllSubmissions:
+
+    @classmethod
+    def setup_class(cls):
+        app.dependency_overrides[get_db] = db_session_mock
+        app.dependency_overrides[mod_service.get_current_admin] = lambda: MagicMock(
+            id="mod_id"
+        )
+
+    @classmethod
+    def teardown_class(cls):
+        app.dependency_overrides = {}
+
+    def test_get_all_submissions(self, client, mocker: MockerFixture):
+        """Test to verify response for getting all submissions."""
+
+        mock_submission_data = [
+            mock_sub(),
+            mock_sub("Who is the first?"),
+        ]
+
+        mocker.patch.object(
+            submission_service, "fetch_all", return_value=mock_submission_data
+        )
+        response = client.get(ENDPOINT_URL.format(""))
+
+        assert response.status_code == 200
+        assert (
+            response.json()["data"][0]["question"] == mock_submission_data[0].question
+        )
+        assert (
+            response.json()["data"][1]["difficulty"]
+            == mock_submission_data[1].difficulty
+        )
+
+    def test_get_all_submissions_empty(self, client, mocker: MockerFixture):
+        """Test to verify response for getting all submissions, even when there are
+        none."""
+
+        mock_submission_data = []
+        mocker.patch.object(
+            submission_service, "fetch_all", return_value=mock_submission_data
+        )
+        response = client.get(ENDPOINT_URL.format(""))
+
+        assert response.status_code == 200
+        assert response.json().get("data") == []
+
+    def test_retrieve_all_submissions_unauthenticated(self, client, mocker):
+        """Test to retrieve all submissions without sign-in"""
+        app.dependency_overrides = {}
+        response = client.get(ENDPOINT_URL.format(""))
+
+        assert response.status_code == 401
+        assert response.json()["message"] == "Could not validate credentials"
+
+    def test_delete_submission_forbidden(self, client, mocker):
+        app.dependency_overrides = {}
+        app.dependency_overrides[get_db] = lambda: mocked_db
+        app.dependency_overrides[bearer_scheme] = lambda: HTTPAuthorizationCredentials(
+            scheme="bearer", credentials="some-token"
+        )
+
+        mocker.patch.object(
+            mod_service,
+            "get_current_mod",
+            return_value=MagicMock(is_admin=False),
+        )
+        response = client.get(ENDPOINT_URL.format("some-id"))
+        assert response.status_code == 403
+        assert (
+            response.json()["message"]
+            == "You do not have permission to access this resource"
+        )

--- a/tests/v1/submission/test_retrieve_categories_countries.py
+++ b/tests/v1/submission/test_retrieve_categories_countries.py
@@ -1,0 +1,46 @@
+import pytest
+
+from unittest.mock import MagicMock
+from pytest_mock import MockerFixture
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from api.db.database import get_db
+from api.v1.schemas.submission import ACE, CategoryEnum
+from main import app
+
+ENDPOINT_URL_CATEGORIES = "/api/v1/submissions/categories"
+ENDPOINT_URL_COUNTRIES = "/api/v1/submissions/countries"
+
+mocked_db = MagicMock(spec=Session)
+
+
+def db_session_mock():
+    yield mocked_db
+
+
+@pytest.fixture
+def client():
+    client = TestClient(app)
+    yield client
+
+
+class TestRetrieveSubmissionCategoriesAndCountries:
+
+    def test_get_countries_success(self, client, mocker: MockerFixture):
+        """Test to verify response for getting list of countries."""
+        response = client.get(ENDPOINT_URL_COUNTRIES)
+
+        assert response.status_code == 200
+        assert response.json().get("data", []) == [country.value for country in ACE]
+
+    def test_get_categories_success(self, client, mocker: MockerFixture):
+        """Test to verify response for getting list of categories."""
+        response = client.get(ENDPOINT_URL_CATEGORIES)
+
+        assert response.status_code == 200
+        assert response.json().get("data", []) == [
+            category.value for category in CategoryEnum
+        ]

--- a/tests/v1/submission/test_retrieve_similars.py
+++ b/tests/v1/submission/test_retrieve_similars.py
@@ -1,0 +1,117 @@
+import pytest
+
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
+from pytest_mock import MockerFixture
+
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+from sqlalchemy.exc import IntegrityError
+from uuid_extensions import uuid7
+
+from api.v1.services.moderator import mod_service
+from api.db.database import get_db
+from api.v1.services.trivia import trivia_service, CountryService, CategoryService
+from api.v1.services.submission import submission_service
+from api.v1.models.trivia import Trivia, TriviaOption
+from api.v1.models.category import Category
+from api.v1.models.country import Country
+from main import app
+
+ENDPOINT_URL = "/api/v1/submissions/{}/similars"
+
+
+def mock_trivia(question="Who"):
+    triv = Trivia(
+        id=str(uuid7()),
+        question=question,
+        difficulty="medium",
+        created_at=datetime.now(timezone.utc),
+        updated_at=datetime.now(timezone.utc),
+    )
+    triv.categories = [Category(name="Politics")]
+    triv.countries = [Country(name="Algeria")]
+
+    triv.options = [
+        TriviaOption(content="Test", is_correct=False),
+        TriviaOption(content="options", is_correct=False),
+        TriviaOption(content="for", is_correct=False),
+        TriviaOption(content="mocked data", is_correct=True),
+    ]
+
+    return triv
+
+
+mocked_db = MagicMock(spec=Session)
+
+
+def db_session_mock():
+    yield mocked_db
+
+
+@pytest.fixture
+def client():
+    client = TestClient(app)
+    yield client
+
+
+class TestRetrieveSimilarTriviasToSubmission:
+
+    @classmethod
+    def setup_class(cls):
+        app.dependency_overrides[get_db] = db_session_mock
+        app.dependency_overrides[mod_service.get_current_mod] = lambda: MagicMock(
+            id="mod_id"
+        )
+
+    @classmethod
+    def teardown_class(cls):
+        app.dependency_overrides = {}
+
+    def test_get_all_similar_trivias(self, client, mocker: MockerFixture):
+        """Test to verify response for getting all similar trivias."""
+
+        mock_trivia_data = [
+            mock_trivia(),
+            mock_trivia("Who is the first?"),
+        ]
+
+        mock_obj = mocker.patch.object(
+            submission_service, "fetch_similars", return_value=mock_trivia_data
+        )
+
+        id = "some-id"
+        response = client.get(ENDPOINT_URL.format(id))
+
+        assert response.status_code == 200
+        mock_obj.assert_called_once_with(db=mocked_db, id=id)
+
+        assert response.status_code == 200
+        assert response.json()["data"][0]["question"] == mock_trivia_data[0].question
+        assert (
+            response.json()["data"][1]["difficulty"] == mock_trivia_data[1].difficulty
+        )
+
+    def test_get_all_similar_trivias_empty(self, client, mocker: MockerFixture):
+        """Test to verify response for getting  similar trivias, even when there are none."""
+
+        mock_trivia_data = []
+        mock_obj = mocker.patch.object(
+            submission_service, "fetch_similars", return_value=mock_trivia_data
+        )
+        id = "some-id"
+        response = client.get(ENDPOINT_URL.format(id))
+        mock_obj.assert_called_once_with(db=mocked_db, id=id)
+
+        assert response.status_code == 200
+        assert response.json().get("data") == []
+
+    def test_retrieve_all_similar_trivias_unauthenticated(self, client, mocker):
+        """Test to retrieve all similar trivias without sign-in"""
+        app.dependency_overrides = {}
+        response = client.get(ENDPOINT_URL.format("some-id"))
+
+        assert response.status_code == 401
+        assert response.json()["message"] == "Could not validate credentials"

--- a/tests/v1/submission/test_retrieve_single_assigned_submission.py
+++ b/tests/v1/submission/test_retrieve_single_assigned_submission.py
@@ -53,7 +53,7 @@ class TestRetrieveSingleSubmissionForMods:
     # Retrieve single nonexistent submission for a moderator
     def test_retrieve_single_submission_nonexistent(self, mocker: MockerFixture):
 
-        mocker.patch.object(submission_service, "fetch", return_value=None)
+        mocker.patch.object(db_session_mock, "get", return_value=None)
 
         response = client.get(ENDPOINT.format("non-existent-submission-id"))
         assert response.status_code == 404

--- a/tests/v1/submission/test_retrieve_submission_stats.py
+++ b/tests/v1/submission/test_retrieve_submission_stats.py
@@ -1,0 +1,51 @@
+import pytest
+
+from unittest.mock import MagicMock
+from pytest_mock import MockerFixture
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from api.db.database import get_db
+from api.v1.services.submission import submission_service
+from main import app
+
+ENDPOINT_URL = "/api/v1/submissions/stats"
+
+mocked_db = MagicMock(spec=Session)
+
+
+def db_session_mock():
+    yield mocked_db
+
+
+@pytest.fixture
+def client():
+    client = TestClient(app)
+    yield client
+
+
+class TestRetrieveSubmissionStats:
+
+    @classmethod
+    def setup_class(cls):
+        app.dependency_overrides[get_db] = db_session_mock
+
+    @classmethod
+    def teardown_class(cls):
+        app.dependency_overrides = {}
+
+    def test_get_stats_success(self, client, mocker: MockerFixture):
+        """Test to verify response for getting submission stats."""
+
+        mock_s = {"total": 5, "approved": 2, "rejected": 2, "pending": 1, "awaiting": 0}
+        mock_fetch = mocker.patch.object(
+            submission_service, "fetch_submission_stats", return_value=mock_s
+        )
+
+        response = client.get(ENDPOINT_URL)
+
+        assert response.status_code == 200
+        mock_fetch.assert_called_once_with(db=mocked_db)
+        assert response.json().get("data", {}).get("total") == mock_s["total"]

--- a/tests/v1/submission/test_review_assigned_submission.py
+++ b/tests/v1/submission/test_review_assigned_submission.py
@@ -79,7 +79,7 @@ class TestRetrieveSingleSubmissionForMods:
     # Approve single nonexistent submission for a moderator
     def test_review_single_submission_nonexistent(self, mocker: MockerFixture):
 
-        mocker.patch.object(submission_service, "fetch", return_value=None)
+        mocker.patch.object(db_session_mock, "get", return_value=None)
 
         response = client.patch(
             ENDPOINT.format("non-existent-submission-id", "approved")


### PR DESCRIPTION
## Description

Created Helper endpoints for submissions.

These endpoints ensure that information surrounding submissions can retrieved and even deleted provided the required permissions are enabled.

The changes include:

- **Endpoint Addition:**

  - Added `GET /api/v1/submissions` for retrieving all submissions. (ADMIN)
  - Added `DELETE /api/v1/submissions/{id}` for deleting single submission.
  - Added `GET /api/v1/submissions/stats` for retrieving stats on submissions present on the database.
  - Added `GET /api/v1/submissions/{id}/similars` retrieves a list of trivias that are similar to a given submission.
  - Added `GET /api/v1/submissions/countries` for retrieving a list of valid countries.
  - Added `GET /api/v1/submissions/categories` for retrieving a list of valid categories.

- **Error Handling:**

  - Implemented checks for invalid submission id.
  - Implemented unauthorized access checks.

- **Helper Functions:** Added utility functions and service methods to help with business logic on the backend.

## Motivation and Context

These endpoints are necessary to aid the review and retrieval of submissions on the backend.

## How Has This Been Tested?

- **Unit Tests:** Endpoint tests were present to validate the CRUD operations performed on the submissions.
- **Test Environment:** Tests were run using a mocked database instance to avoid interference with the dev environment.

Tests include:

- Retrieving all submissions by authorized mod.
- Retrieving a list of trivias similar to a given submission.
- Deletion of a submission by an admin.

## Screenshots:

### Retrieve all submissions

![image](https://github.com/user-attachments/assets/f24e3af6-b6d4-4f3e-a955-40e489e7d6b7)

### Get submission stats

![image](https://github.com/user-attachments/assets/68cd4a45-6b14-4cac-b629-af24dcfaebf3)

### Get trivias similar to a submission

![image](https://github.com/user-attachments/assets/4288b64f-e512-4731-9637-e48d9ca6eda9)

### Get a list of all valid countries

![image](https://github.com/user-attachments/assets/b64c3140-a386-42f4-8003-0a4e47e0f454)

### Get a list of all valid categories

![image](https://github.com/user-attachments/assets/d7fdeddc-aed2-494c-81c1-26de371df507)

### Delete single submission

![image](https://github.com/user-attachments/assets/c278bbc9-c433-4cff-89cf-e986114eb56d)

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
