### PR TITLE
feat: endpoint to reassign submission to another moderator

### DIFF
--- a/api/v1/routes/submission.py
+++ b/api/v1/routes/submission.py
@@ -263,3 +263,34 @@ async def retrieve_valid_categories():
         message="Successfully retrieved all valid categories",
         status_code=200,
     )
+
+
+@submissions.patch(
+    "/{id}/reassign",
+    response_model=s_schema.GetSubmissionForModResponseModelSchema,
+    status_code=200,
+)
+async def reassign_submission(
+    id: str,
+    schema: s_schema.AlterModForSubmissionSchema,
+    db: Session = Depends(get_db),
+    mod: Moderator = Depends(mod_service.get_current_admin),
+):
+    """Endpoint to reassign a given submission to a valid and active mod.
+
+    Args:
+        id (str): The id of the submission to be reassigned
+        schema (s_schema.AlterModForSubmissionSchema): The schema used for the change
+        db (Session): The db session object.
+        mod (Moderator): The admin making request
+    """
+    subm = submission_service.reassign(db=db, id=id, new_mod_id=schema.moderator_id)
+    validated_schema = s_schema.PostSubmissionResponseSchema.model_validate(
+        subm.to_dict()
+    )
+
+    return success_response(
+        data=jsonable_encoder(validated_schema),
+        message="Successfully reassigned submission",
+        status_code=200,
+    )

--- a/api/v1/schemas/submission.py
+++ b/api/v1/schemas/submission.py
@@ -3,6 +3,7 @@ from datetime import datetime
 from api.v1.schemas.african_countries_enum import AfricanCountriesEnum as ACE
 from api.v1.schemas.base_schemas import BaseSuccessResponseSchema
 from enum import Enum
+from uuid import UUID
 
 
 class DifficultyEnum(str, Enum):
@@ -102,3 +103,7 @@ class GetListOfCountriesResponseModelSchema(BaseSuccessResponseSchema):
 
 class GetListOfCategoriesResponseModelSchema(BaseSuccessResponseSchema):
     data: list[CategoryEnum]
+
+
+class AlterModForSubmissionSchema(BaseModel):
+    moderator_id: str = Field(min_length=36, max_length=36)

--- a/tests/v1/submission/test_reassign_submission.py
+++ b/tests/v1/submission/test_reassign_submission.py
@@ -131,6 +131,20 @@ class TestRetrieveAllSubmissions:
         assert response.status_code == 400
         assert response.json()["message"] == "Moderator does not exist or is inactive"
 
+    def test_reassign_submission_invalid_id(self, client, mocker: MockerFixture):
+        """Test to verify unsuccessful reassignment of submission as submission is nonexistent"""
+        mocked_sub = mock_sub()
+
+        mocker.patch.object(mocked_db, "get", return_value=None)
+
+        r_id = str(uuid7())
+        response = client.patch(
+            ENDPOINT_URL.format(mocked_sub.id), json={"moderator_id": r_id}
+        )
+
+        assert response.status_code == 404
+        assert response.json()["message"] == "Submission not found"
+
     def test_reassign_submission_mod_inactive(self, client, mocker: MockerFixture):
         """Test to verify unsuccessful reassignment of submission as mod is inactive."""
         mocked_sub = mock_sub()

--- a/tests/v1/submission/test_reassign_submission.py
+++ b/tests/v1/submission/test_reassign_submission.py
@@ -1,0 +1,187 @@
+import pytest
+
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
+from pytest_mock import MockerFixture
+
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+from uuid_extensions import uuid7
+
+from api.v1.services.moderator import (
+    bearer_scheme,
+    mod_service,
+    HTTPAuthorizationCredentials,
+)
+from api.db.database import get_db
+from api.v1.services.submission import submission_service
+from api.v1.models.submission import Submission, SubmissionOption
+from api.v1.models.category import Category
+from api.v1.models.country import Country
+from api.v1.models.moderator import Moderator
+from main import app
+
+ENDPOINT_URL = "/api/v1/submissions/{}/reassign"
+
+
+def mock_sub(question="Who"):
+    subm = Submission(
+        id=str(uuid7()),
+        status="pending",
+        question=question,
+        moderator_id=str(uuid7()),
+        difficulty="medium",
+        created_at=datetime.now(timezone.utc),
+        updated_at=datetime.now(timezone.utc),
+    )
+    subm.categories = [Category(name="Politics")]
+    subm.countries = [Country(name="Algeria")]
+
+    subm.options = [
+        SubmissionOption(content="Test", is_correct=False),
+        SubmissionOption(content="options", is_correct=False),
+        SubmissionOption(content="for", is_correct=False),
+        SubmissionOption(content="mocked data", is_correct=True),
+    ]
+
+    return subm
+
+
+def mock_mod(is_active=True):
+    mod = Moderator(
+        id=str(uuid7()),
+        first_name="John",
+        last_name="Doe",
+        username="johndoe",
+        email="john.doe@example.com",
+        password="password123",
+        created_at=datetime.now(timezone.utc),
+        updated_at=datetime.now(timezone.utc),
+        is_active=is_active,
+    )
+
+    return mod
+
+
+mocked_db = MagicMock(spec=Session)
+
+
+def db_session_mock():
+    yield mocked_db
+
+
+@pytest.fixture
+def client():
+    client = TestClient(app)
+    yield client
+
+
+class TestRetrieveAllSubmissions:
+
+    @classmethod
+    def setup_class(cls):
+        app.dependency_overrides[get_db] = db_session_mock
+        app.dependency_overrides[mod_service.get_current_admin] = lambda: MagicMock(
+            id="mod_id"
+        )
+
+    @classmethod
+    def teardown_class(cls):
+        app.dependency_overrides = {}
+
+    def test_reassign_submission_success(self, client, mocker: MockerFixture):
+        """Test to verify reassignment of submission."""
+        mocked_sub = mock_sub()
+        mocked_mod = mock_mod()
+
+        m_patch = mocker.patch.object(mod_service, "fetch", return_value=mocked_mod)
+        s_patch = mocker.patch.object(
+            submission_service, "fetch", return_value=mocked_sub
+        )
+
+        response = client.patch(
+            ENDPOINT_URL.format(mocked_sub.id), json={"moderator_id": mocked_mod.id}
+        )
+
+        m_patch.assert_called_once_with(db=mocked_db, id=mocked_mod.id)
+        s_patch.assert_called_once_with(db=mocked_db, id=mocked_sub.id, raise_404=True)
+
+        assert response.status_code == 200
+        assert response.json()["data"]["moderator_id"] == mocked_mod.id
+        assert response.json()["data"]["question"] == mocked_sub.question
+
+    def test_reassign_submission_invalid_mod(self, client, mocker: MockerFixture):
+        """Test to verify unsuccessful reassignment of submission as mod is nonexistent"""
+        mocked_sub = mock_sub()
+
+        m_patch = mocker.patch.object(mod_service, "fetch", return_value=None)
+        s_patch = mocker.patch.object(
+            submission_service, "fetch", return_value=mocked_sub
+        )
+        r_id = str(uuid7())
+        response = client.patch(
+            ENDPOINT_URL.format(mocked_sub.id), json={"moderator_id": r_id}
+        )
+
+        m_patch.assert_called_once_with(db=mocked_db, id=r_id)
+        s_patch.assert_called_once_with(db=mocked_db, id=mocked_sub.id, raise_404=True)
+
+        assert response.status_code == 400
+        assert response.json()["message"] == "Moderator does not exist or is inactive"
+
+    def test_reassign_submission_mod_inactive(self, client, mocker: MockerFixture):
+        """Test to verify unsuccessful reassignment of submission as mod is inactive."""
+        mocked_sub = mock_sub()
+        mocked_mod = mock_mod(is_active=False)
+
+        m_patch = mocker.patch.object(mod_service, "fetch", return_value=mocked_mod)
+        s_patch = mocker.patch.object(
+            submission_service, "fetch", return_value=mocked_sub
+        )
+
+        response = client.patch(
+            ENDPOINT_URL.format(mocked_sub.id), json={"moderator_id": mocked_mod.id}
+        )
+
+        m_patch.assert_called_once_with(db=mocked_db, id=mocked_mod.id)
+        s_patch.assert_called_once_with(db=mocked_db, id=mocked_sub.id, raise_404=True)
+
+        assert response.status_code == 400
+        assert response.json()["message"] == "Moderator does not exist or is inactive"
+
+    def test_reassign_submission_invalid_mod_id(self, client, mocker: MockerFixture):
+        """Test to verify unsuccessful reassignment of submission as mod id format is incorrect."""
+        response = client.patch(
+            ENDPOINT_URL.format("random-id"), json={"moderator_id": "random-mod-id"}
+        )
+
+        assert response.status_code == 422
+
+    def test_reassign_submissions_unauthenticated(self, client, mocker):
+        """Test to reassign submissions without sign-in"""
+        app.dependency_overrides = {}
+        response = client.patch(ENDPOINT_URL.format("sub-id"))
+
+        assert response.status_code == 401
+        assert response.json()["message"] == "Could not validate credentials"
+
+    def test_reassign_submissions_forbidden(self, client, mocker):
+        app.dependency_overrides = {}
+        app.dependency_overrides[get_db] = lambda: mocked_db
+        app.dependency_overrides[bearer_scheme] = lambda: HTTPAuthorizationCredentials(
+            scheme="bearer", credentials="some-token"
+        )
+
+        mocker.patch.object(
+            mod_service,
+            "get_current_mod",
+            return_value=MagicMock(is_admin=False),
+        )
+        response = client.patch(ENDPOINT_URL.format("some-id"))
+        assert response.status_code == 403
+        assert (
+            response.json()["message"]
+            == "You do not have permission to access this resource"
+        )


### PR DESCRIPTION
## Description

Create endpoint to reassign submissions.

This endpoint allows an admin reassign a given submission to another moderator.

The changes include:

- **Endpoint Addition:**

  - Added `PATCH /api/v1/submissions/{id}/reassign` for reassigning a single submission. [ADMIN]
    - Request Body
    ```json
    {
      "moderator_id": "<string>"
    }
    ```

- **Error Handling:**

  - Implemented checks for invalid submission id.
  - Implemented checks for invalid request body.
  - Implemented unauthorized access checks.

- **Helper Functions:** Added utility functions and service methods to help with business logic on the backend.

## Motivation and Context

This endpoint helps the admin reassign a given submission on the database to another moderator.

## How Has This Been Tested?

- **Unit Tests:** Endpoint tests were present to validate the reassign operations performed on the submissions.
- **Test Environment:** Tests were run using a mocked database instance to avoid interference with the dev environment.

Tests include:

- Reassigning submission to another mod.
- Reassigning non-existent submission.
- Reassigning to non-existent moderator.

## Screenshots:

### Reassign successfully

![image](https://github.com/user-attachments/assets/1689b58a-19ea-469f-a691-c22e1957cce3)

### Malformed moderator id

![image](https://github.com/user-attachments/assets/c2de906f-e153-4e1b-9ae2-147ec18a1dd8)

### Moderator inactive or non-existent

![image](https://github.com/user-attachments/assets/a6ede003-7a3b-4e00-9b29-d3c50ef00a37)

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
