### PR TITLE
feat: endpoints to retrieve, deactivate and delete moderator

### DIFF
--- a/api/v1/models/moderator.py
+++ b/api/v1/models/moderator.py
@@ -35,4 +35,8 @@ class Moderator(BaseTableModel):
             map(lambda x: x.name, self.country_preferences)
         )
 
+        obj_dict["pending_submissions"] = [
+            x.id for x in self.assigned_submissions if x.status == "pending"
+        ]
+
         return obj_dict

--- a/api/v1/routes/moderator.py
+++ b/api/v1/routes/moderator.py
@@ -9,6 +9,7 @@ from api.v1.schemas.moderator import (
     GetModeratorResponseModelSchema,
     ChangePasswordSchema,
     RetrieveModeratorsModelResponseSchema,
+    ReturnModeratorDataForAdmin,
 )
 from api.v1.services.moderator import mod_service, Moderator
 from api.utils.logger import logger
@@ -74,7 +75,7 @@ async def retrieve_all_moderators(
     mods = mod_service.fetch_all(db=db)
 
     validated_m_dict = [
-        CreateModeratorResponseSchema.model_validate(m.to_dict()) for m in mods
+        ReturnModeratorDataForAdmin.model_validate(m.to_dict()) for m in mods
     ]
 
     return success_response(
@@ -127,7 +128,7 @@ async def deactivate_moderator(
 
     return success_response(
         status_code=200,
-        message=f"Moderator successfully activated",
+        message=f"Moderator successfully deactivated",
         data=CreateModeratorResponseSchema.model_validate(mod.to_dict()),
     )
 
@@ -136,7 +137,7 @@ async def deactivate_moderator(
     "/{id}",
     status_code=204,
 )
-async def delete_single_trivia(
+async def delete_single_moderator(
     id: str,
     db: Session = Depends(get_db),
     mod: Moderator = Depends(mod_service.get_current_admin),

--- a/api/v1/routes/moderator.py
+++ b/api/v1/routes/moderator.py
@@ -8,6 +8,7 @@ from api.v1.schemas.moderator import (
     CreateModeratorResponseSchema,
     GetModeratorResponseModelSchema,
     ChangePasswordSchema,
+    RetrieveModeratorsModelResponseSchema,
 )
 from api.v1.services.moderator import mod_service, Moderator
 from api.utils.logger import logger
@@ -53,3 +54,96 @@ def change_password(
     return success_response(
         status_code=status.HTTP_200_OK, message="Password changed successfully!!"
     )
+
+
+@moderator.get(
+    "",
+    response_model=RetrieveModeratorsModelResponseSchema,
+    status_code=200,
+)
+async def retrieve_all_moderators(
+    db: Session = Depends(get_db),
+    mod: Moderator = Depends(mod_service.get_current_admin),
+):
+    """Endpoint to retrieve all moderators.
+
+    Args:
+        db (Session, optional): The db session object.
+        mod (Moderator): The admin making the request.
+    """
+    mods = mod_service.fetch_all(db=db)
+
+    validated_m_dict = [
+        CreateModeratorResponseSchema.model_validate(m.to_dict()) for m in mods
+    ]
+
+    return success_response(
+        data=jsonable_encoder(validated_m_dict),
+        message="Successfully retrieved all moderators",
+        status_code=200,
+    )
+
+
+@moderator.patch(
+    "/{id}/activate",
+    response_model=GetModeratorResponseModelSchema,
+    status_code=200,
+)
+async def activate_moderator(
+    id: str,
+    db: Session = Depends(get_db),
+    current_mod: Moderator = Depends(mod_service.get_current_admin),
+):
+    """Endpoint for admin to activate a deactivated moderator's account"""
+
+    mod = mod_service.deactivateOrActivate(
+        db=db, id_target=id, current_mod=current_mod, is_active=True
+    )
+
+    return success_response(
+        status_code=200,
+        message=f"Moderator successfully activated",
+        data=CreateModeratorResponseSchema.model_validate(mod.to_dict()),
+    )
+
+
+@moderator.patch(
+    "/{id}/deactivate",
+    response_model=GetModeratorResponseModelSchema,
+    status_code=200,
+)
+async def deactivate_moderator(
+    id: str,
+    db: Session = Depends(get_db),
+    current_mod: Moderator = Depends(mod_service.get_current_mod),
+):
+    """Endpoint for admin or a mod to deactivate a moderator's account
+    Regular mods can only deactivate their own account
+    """
+
+    mod = mod_service.deactivateOrActivate(
+        db=db, id_target=id, current_mod=current_mod, is_active=False
+    )
+
+    return success_response(
+        status_code=200,
+        message=f"Moderator successfully activated",
+        data=CreateModeratorResponseSchema.model_validate(mod.to_dict()),
+    )
+
+
+@moderator.delete(
+    "/{id}",
+    status_code=204,
+)
+async def delete_single_trivia(
+    id: str,
+    db: Session = Depends(get_db),
+    mod: Moderator = Depends(mod_service.get_current_admin),
+):
+    """Endpoint to delete a single moderator.
+
+    Args:
+        db (Session, optional): The db session object.
+    """
+    status = mod_service.delete(db=db, id_target=id, current_admin=mod)

--- a/api/v1/routes/submission.py
+++ b/api/v1/routes/submission.py
@@ -180,7 +180,6 @@ async def delete_single_submission(
         db (Session, optional): The db session object.
     """
     status = submission_service.delete(db=db, id=id)
-    print(status)
 
 
 @submissions.get(

--- a/api/v1/routes/trivia.py
+++ b/api/v1/routes/trivia.py
@@ -140,4 +140,3 @@ async def delete_single_trivia(
         db (Session, optional): The db session object.
     """
     status = trivia_service.delete(db=db, id=id)
-    print(status)

--- a/api/v1/schemas/moderator.py
+++ b/api/v1/schemas/moderator.py
@@ -86,3 +86,7 @@ class UpdateModeratorByAdminSchema(UpdateModeratorSchema):
 
 class DeactivateModeratorSchema(BaseModel):
     is_active: bool
+
+
+class RetrieveModeratorsModelResponseSchema(BaseSuccessResponseSchema):
+    data: list[CreateModeratorResponseSchema]

--- a/api/v1/schemas/moderator.py
+++ b/api/v1/schemas/moderator.py
@@ -88,5 +88,9 @@ class DeactivateModeratorSchema(BaseModel):
     is_active: bool
 
 
+class ReturnModeratorDataForAdmin(CreateModeratorResponseSchema):
+    pending_submissions: list[str]
+
+
 class RetrieveModeratorsModelResponseSchema(BaseSuccessResponseSchema):
-    data: list[CreateModeratorResponseSchema]
+    data: list[ReturnModeratorDataForAdmin]

--- a/api/v1/services/moderator.py
+++ b/api/v1/services/moderator.py
@@ -49,8 +49,17 @@ class ModeratorService(Service):
         headers={"WWW-Authenticate": "Bearer"},
     )
 
-    def fetch_all():
-        pass
+    def fetch_all(self, db: Session) -> list[Moderator]:
+        """Fetches all moderators from the database
+
+        Args:
+            db (Session): Db session object
+
+        Returns:
+            list[Moderator]: A list of all Moderator objects on the database
+        """
+        all_moderators = db.query(Moderator).all()
+        return all_moderators
 
     def fetch(self, db: Session, id: str):
         """Fetches a moderator by their id"""
@@ -154,7 +163,8 @@ class ModeratorService(Service):
         current_mod: Moderator,
         is_active: bool = False,
     ) -> Moderator:
-        """Function to deactivate or reactivate a mod. Only an admin or the target mod has permission.
+        """Function to deactivate or reactivate a mod.
+        Only an admin or the target mod has permission to make changes.
 
         Args:
             db (Session):
@@ -172,16 +182,16 @@ class ModeratorService(Service):
         if current_mod.is_admin is not True and id_target != current_mod.id:
             raise self.FORBIDDEN_EXC
 
-        mod = self.fetch(db=db, id=id_target)
+        target_mod = self.fetch(db=db, id=id_target)
 
-        if not mod:
+        if not target_mod:
             raise self.NOT_FOUND_EXC
 
-        mod.is_active = is_active
+        target_mod.is_active = is_active
         db.commit()
-        db.refresh(mod)
+        db.refresh(target_mod)
 
-        return mod
+        return target_mod
 
     def delete(self, db: Session, id_target: str, current_admin: Moderator) -> bool:
         """Function to delete a mod account. Only an admin has permission.

--- a/api/v1/services/trivia.py
+++ b/api/v1/services/trivia.py
@@ -185,7 +185,6 @@ class TriviaService(Service):
                 existing_options: list[TriviaOption] = trivia.options
                 # Existing options sorted with correct option last
                 existing_options.sort(key=lambda x: x.is_correct)
-                # print(list(map(lambda x: x.content, options_models_list)))
                 for i in range(len((existing_options))):
                     # Find and update correct option model first, if applicable
                     if len(options_models_list) == 1:

--- a/tests/v1/moderator/test_activate_deactivate_mod.py
+++ b/tests/v1/moderator/test_activate_deactivate_mod.py
@@ -1,0 +1,170 @@
+import pytest
+
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
+from pytest_mock import MockerFixture
+
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+from uuid_extensions import uuid7
+
+from api.v1.services.moderator import (
+    bearer_scheme,
+    mod_service,
+    HTTPAuthorizationCredentials,
+)
+from api.db.database import get_db
+from api.v1.models.moderator import Moderator
+from main import app
+
+ENDPOINT_URL_ACTIVATE = "/api/v1/moderators/{}/activate"
+ENDPOINT_URL_DEACTIVATE = "/api/v1/moderators/{}/deactivate"
+
+
+def mock_mod(is_admin=False, first_name="John", is_active=False):
+    mod = Moderator(
+        id=str(uuid7()),
+        first_name=first_name,
+        last_name="Doe",
+        username="johndoe",
+        email="john.doe@example.com",
+        password="password123",
+        created_at=datetime.now(timezone.utc),
+        updated_at=datetime.now(timezone.utc),
+        is_active=is_active,
+        is_admin=is_admin,
+    )
+
+    return mod
+
+
+mocked_db = MagicMock(spec=Session)
+
+
+def db_session_mock():
+    yield mocked_db
+
+
+@pytest.fixture
+def client():
+    client = TestClient(app)
+    yield client
+
+
+class TestActivateDeactivateModerator:
+
+    @classmethod
+    def setup_class(cls):
+        app.dependency_overrides[get_db] = db_session_mock
+
+    @classmethod
+    def teardown_class(cls):
+        app.dependency_overrides = {}
+
+    def test_activate_moderator_success(self, client, mocker: MockerFixture):
+        """Test to verify successful activation of moderator."""
+        mocked_adm = mock_mod(is_admin=True)
+        mocked_mod = mock_mod()
+        app.dependency_overrides[mod_service.get_current_admin] = lambda: mocked_adm
+
+        m_patch = mocker.patch.object(mod_service, "fetch", return_value=mocked_mod)
+
+        response = client.patch(ENDPOINT_URL_ACTIVATE.format(mocked_mod.id))
+
+        m_patch.assert_called_once_with(db=mocked_db, id=mocked_mod.id)
+
+        assert response.status_code == 200
+        assert response.json()["data"]["is_active"] == True
+        assert mocked_mod.is_active == True
+
+    def test_deactivate_moderator_success_admin(self, client, mocker: MockerFixture):
+        """Test to verify successful deactivation of moderator by admin"""
+        mocked_adm = mock_mod(is_admin=True)
+        mocked_mod = mock_mod()
+        app.dependency_overrides[mod_service.get_current_mod] = lambda: mocked_adm
+
+        m_patch = mocker.patch.object(mod_service, "fetch", return_value=mocked_mod)
+        response = client.patch(ENDPOINT_URL_DEACTIVATE.format(mocked_mod.id))
+
+        m_patch.assert_called_once_with(db=mocked_db, id=mocked_mod.id)
+
+        assert response.status_code == 200
+        assert response.json()["data"]["is_active"] == False
+        assert mocked_mod.is_active == False
+
+    def test_deactivate_moderator_success_same_mod(self, client, mocker: MockerFixture):
+        """Test to verify successful deactivation of moderator."""
+        # app.dependency_overrides[mod_service.get_current_admin] = lambda: MagicMock(
+        # is_admin=False
+        # )
+        """Test to verify successful deactivation of moderator."""
+        mocked_mod = mock_mod(is_active=True)
+        app.dependency_overrides[mod_service.get_current_mod] = lambda: mocked_mod
+
+        m_patch = mocker.patch.object(mod_service, "fetch", return_value=mocked_mod)
+
+        response = client.patch(ENDPOINT_URL_DEACTIVATE.format(mocked_mod.id))
+
+        m_patch.assert_called_once_with(db=mocked_db, id=mocked_mod.id)
+
+        assert response.status_code == 200
+        assert response.json()["data"]["is_active"] == False
+        assert mocked_mod.is_active == False
+
+    def test_activate_moderator_unsuccessful_not_admin(
+        self, client, mocker: MockerFixture
+    ):
+        """Test to verify unsuccessful activation of moderator."""
+        # app.dependency_overrides[mod_service.get_current_admin] = lambda: MagicMock(
+        # is_admin=False
+        # )
+        mocked_mod = mock_mod(is_admin=False)
+        app.dependency_overrides[mod_service.get_current_admin] = lambda: mocked_mod
+
+        response = client.patch(ENDPOINT_URL_ACTIVATE.format(str(uuid7())))
+        assert response.status_code == 403
+
+    def test_deactivate_moderator_unsuccessful_not_admin(
+        self, client, mocker: MockerFixture
+    ):
+        """Test to verify unsuccessful deactivation of moderator."""
+        # app.dependency_overrides[mod_service.get_current_admin] = lambda: MagicMock(
+        # is_admin=False
+        # )
+        mocker.patch.object(
+            mod_service, "get_current_mod", return_value=MagicMock(is_admin=False)
+        )
+        response = client.patch(ENDPOINT_URL_DEACTIVATE.format(str(uuid7())))
+
+        assert response.status_code == 403
+
+    def test_deactivate_moderator_unsuccessful_not_same_mod(
+        self, client, mocker: MockerFixture
+    ):
+        """Test to verify unsuccessful deactivation of moderator."""
+        # app.dependency_overrides[mod_service.get_current_admin] = lambda: MagicMock(
+        # is_admin=False
+        # )
+        """Test to verify successful deactivation of moderator."""
+        mocked_mod = mock_mod()
+        app.dependency_overrides[mod_service.get_current_mod] = lambda: mocked_mod
+
+        m_patch = mocker.patch.object(mod_service, "fetch", return_value=mocked_mod)
+
+        response = client.patch(ENDPOINT_URL_DEACTIVATE.format("not-same-id"))
+
+        assert response.status_code == 403
+
+    def test_deactivate_moderator_invalid_id(self, client, mocker: MockerFixture):
+        """Test to verify successful deactivation of moderator."""
+        app.dependency_overrides[mod_service.get_current_mod] = lambda: MagicMock(
+            id="mod_id", is_admin=True
+        )
+        mocked_mod = None
+        mocker.patch.object(mod_service, "fetch", return_value=mocked_mod)
+
+        response = client.patch(ENDPOINT_URL_DEACTIVATE.format("random-id"))
+        assert response.status_code == 404
+        assert response.json()["message"] == "Moderator not found"

--- a/tests/v1/moderator/test_delete_moderator.py
+++ b/tests/v1/moderator/test_delete_moderator.py
@@ -1,0 +1,115 @@
+import pytest
+
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
+from pytest_mock import MockerFixture
+from uuid_extensions import uuid7
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+from api.v1.services.moderator import (
+    bearer_scheme,
+    mod_service,
+    HTTPAuthorizationCredentials,
+)
+
+from api.db.database import get_db
+from api.v1.services.submission import mod_service
+from api.v1.models.moderator import Moderator
+from main import app
+
+ENDPOINT_URL = "/api/v1/moderators/{}"
+
+
+def mock_mod(is_admin=False, first_name="John", is_active=False):
+    mod = Moderator(
+        id=str(uuid7()),
+        first_name=first_name,
+        last_name="Doe",
+        username="johndoe",
+        email="john.doe@example.com",
+        password="password123",
+        created_at=datetime.now(timezone.utc),
+        updated_at=datetime.now(timezone.utc),
+        is_active=is_active,
+        is_admin=is_admin,
+    )
+
+    return mod
+
+
+mocked_db = MagicMock(spec=Session)
+
+
+def db_session_mock():
+    yield mocked_db
+
+
+@pytest.fixture
+def client():
+    client = TestClient(app)
+    yield client
+
+
+class TestClassDeleteSubmission:
+    @classmethod
+    def setup_class(cls):
+        cls.mock_adm = mock_mod(is_admin=True)
+        app.dependency_overrides[get_db] = db_session_mock
+        app.dependency_overrides[mod_service.get_current_admin] = lambda: cls.mock_adm
+
+    @classmethod
+    def teardown_class(cls):
+        app.dependency_overrides = {}
+
+    # Successfully delete moderator from the database
+    def test_delete_moderator_success(self, client: TestClient, mocker: MockerFixture):
+        mock_s = mock_mod()
+        mock_fetch = mocker.patch.object(mod_service, "delete", return_value=True)
+
+        response = client.delete(ENDPOINT_URL.format(mock_s.id))
+
+        assert response.status_code == 204
+        mock_fetch.assert_called_once_with(
+            db=mocked_db,
+            id_target=mock_s.id,
+            current_admin=TestClassDeleteSubmission.mock_adm,
+        )
+
+    # Invalid id
+    def test_delete_moderator_invalid_id(self, client, mocker):
+
+        mocker.patch.object(mocked_db, "get", return_value=None)
+
+        response = client.delete(ENDPOINT_URL.format("some-id"))
+        assert response.status_code == 404
+        assert response.json()["message"] == "Moderator not found"
+
+    # Handling unauthenticated request
+    def test_delete_moderator_unauthenticated(self, client):
+        app.dependency_overrides = {}
+
+        response = client.delete(ENDPOINT_URL.format("some-id"))
+        assert response.status_code == 401
+        assert response.json()["message"] == "Could not validate credentials"
+
+    # Handling forbidden request
+    def test_delete_moderator_forbidden(self, client, mocker):
+        app.dependency_overrides = {}
+        app.dependency_overrides[get_db] = lambda: mocked_db
+        app.dependency_overrides[bearer_scheme] = lambda: HTTPAuthorizationCredentials(
+            scheme="bearer", credentials="some-token"
+        )
+
+        mocker.patch.object(
+            mod_service,
+            "get_current_mod",
+            return_value=MagicMock(is_admin=False),
+        )
+        response = client.delete(ENDPOINT_URL.format("some-id"))
+        assert response.status_code == 403
+        assert (
+            response.json()["message"]
+            == "You do not have permission to access this resource"
+        )

--- a/tests/v1/moderator/test_retrieve_mods.py
+++ b/tests/v1/moderator/test_retrieve_mods.py
@@ -1,0 +1,120 @@
+import pytest
+
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
+from pytest_mock import MockerFixture
+
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+from uuid_extensions import uuid7
+
+from api.v1.services.moderator import (
+    bearer_scheme,
+    mod_service,
+    HTTPAuthorizationCredentials,
+)
+from api.db.database import get_db
+from api.v1.models.moderator import Moderator
+from main import app
+
+ENDPOINT_URL = "/api/v1/moderators"
+
+
+def mock_mod(is_active=True, first_name="John"):
+    mod = Moderator(
+        id=str(uuid7()),
+        first_name=first_name,
+        last_name="Doe",
+        username="johndoe",
+        email="john.doe@example.com",
+        password="password123",
+        created_at=datetime.now(timezone.utc),
+        updated_at=datetime.now(timezone.utc),
+        is_active=is_active,
+        is_admin=False,
+    )
+
+    return mod
+
+
+mocked_db = MagicMock(spec=Session)
+
+
+def db_session_mock():
+    yield mocked_db
+
+
+@pytest.fixture
+def client():
+    client = TestClient(app)
+    yield client
+
+
+class TestRetrieveAllModerators:
+
+    @classmethod
+    def setup_class(cls):
+        app.dependency_overrides[get_db] = db_session_mock
+        app.dependency_overrides[mod_service.get_current_admin] = lambda: MagicMock(
+            id="mod_id"
+        )
+
+    @classmethod
+    def teardown_class(cls):
+        app.dependency_overrides = {}
+
+    def test_get_all_moderators(self, client, mocker: MockerFixture):
+        """Test to verify response for getting all moderators."""
+
+        mock_data = [
+            mock_mod(),
+            mock_mod(first_name="Whoo?"),
+        ]
+
+        mocker.patch.object(mod_service, "fetch_all", return_value=mock_data)
+        response = client.get(ENDPOINT_URL)
+
+        assert response.status_code == 200
+        assert response.json()["data"][0]["first_name"] == mock_data[0].first_name
+        assert response.json()["data"][1]["first_name"] == mock_data[1].first_name
+
+    def test_get_all_moderators_empty(self, client, mocker: MockerFixture):
+        """Test to verify response for getting all moderators, even when there are
+        none."""
+
+        mock_data = []
+        mocker.patch.object(mod_service, "fetch_all", return_value=mock_data)
+        response = client.get(ENDPOINT_URL)
+
+        assert response.status_code == 200
+        assert response.json().get("data") == []
+
+    def test_retrieve_all_moderators_unauthenticated(self, client, mocker):
+        """Test to retrieve all moderators without sign-in"""
+        app.dependency_overrides = {}
+        response = client.get(ENDPOINT_URL)
+
+        assert response.status_code == 401
+        assert response.json()["message"] == "Could not validate credentials"
+
+    def test_retrieve_all_moderators_forbidden(self, client, mocker):
+        """Test to retrieve all moderators when not admin"""
+        app.dependency_overrides = {}
+        app.dependency_overrides[get_db] = lambda: mocked_db
+        app.dependency_overrides[bearer_scheme] = lambda: HTTPAuthorizationCredentials(
+            scheme="bearer", credentials="some-token"
+        )
+
+        mocker.patch.object(
+            mod_service,
+            "get_current_mod",
+            return_value=MagicMock(is_admin=False),
+        )
+        response = client.get(ENDPOINT_URL)
+        assert response.status_code == 403
+        assert (
+            response.json()["message"]
+            == "You do not have permission to access this resource"
+        )

--- a/tests/v1/submission/test_reassign_submission.py
+++ b/tests/v1/submission/test_reassign_submission.py
@@ -78,7 +78,7 @@ def client():
     yield client
 
 
-class TestRetrieveAllSubmissions:
+class TestReassignSubmissions:
 
     @classmethod
     def setup_class(cls):

--- a/tests/v1/submission/test_submission_service_methods.py
+++ b/tests/v1/submission/test_submission_service_methods.py
@@ -80,7 +80,6 @@ mock_db_store = [
 
 
 def mock_fetch_paginated(db: Session, skip: int, limit: int, filters: dict[str]):
-    print(db, skip, limit, filters)
     mock_data = {
         "items": [],
         "total": 0,


### PR DESCRIPTION
## Description

Added more endpoints for moderators.

These endpoints ensure that moderators/admins can deactivate, activate, delete and retrieve moderators on the backend.

The changes include:

- **Endpoint Addition:**

  - Added `GET /api/v1/moderators` for retrieving all moderators.
  - Added `PATCH /api/v1/moderators/{id}/activate` for admins to activate given moderator.
  - Added `PATCH /api/v1/moderators/{id}/deactivate` for moderators/admins to deactivate self/moderator.
  - Added `DELETE /api/v1/moderators/{id}` for admins to delete a moderator.

- **Error Handling:**

  - Implemented checks for invalid moderator id.
  - Implemented unauthorized access checks.

- **Helper Functions:** Added utility functions and service methods to help with business logic on the backend.

## Motivation and Context

These endpoints are necessary to facilitate the manipulation of moderator(s) stored on the backend.

## How Has This Been Tested?

- **Unit Tests:** Service functions tests were present to validate the CRUD operations performed on the moderators.
- **Test Environment:** Tests were run using a mocked database instance to avoid interference with the dev environment.

Tests include:

- Deactivate/Activate a moderator by an authenticated admin.
- Retrieving all moderators present.

## Screenshots:

### Retrieve all Moderators

![image](https://github.com/user-attachments/assets/e409232f-a4d9-493e-9dac-f78cdf7b254d)

### Deactivate a moderator

![image](https://github.com/user-attachments/assets/bb70a7e8-80c1-4e4d-88fa-d1ba852f88e3)

### Activate a moderator

![image](https://github.com/user-attachments/assets/48b32549-20c2-45ef-b47a-54c6c9b5b719)

### Delete a moderator

![image](https://github.com/user-attachments/assets/14b45c61-dbce-49a0-907d-cde28f87d517)

### Delete non-existing moderator

![image](https://github.com/user-attachments/assets/505b10fc-2f0e-454b-98fe-33a31ee2e8c3)

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.