### PR TITLE
chore: implemented check to keep deactivated accounts from login

### DIFF
--- a/api/v1/services/moderator.py
+++ b/api/v1/services/moderator.py
@@ -225,13 +225,16 @@ class ModeratorService(Service):
     def authenticate_mod(self, db: Session, email: EmailStr, password: str):
         """Function to authenticate a moderator"""
 
-        mod = self.fetch_by_email(db, email=email)
+        mod: Moderator = self.fetch_by_email(db, email=email)
 
         if not mod:
             raise HTTPException(status_code=400, detail="Invalid user credentials")
 
         if not self.verify_password(password, mod.password):
             raise HTTPException(status_code=400, detail="Invalid user credentials")
+
+        if mod.is_active is False:
+            raise HTTPException(status_code=401, detail="Deactivated account")
 
         return mod
 

--- a/tests/v1/moderator/test_mod_service_functions.py
+++ b/tests/v1/moderator/test_mod_service_functions.py
@@ -148,6 +148,22 @@ class TestModeratorService:
             assert exc.value.status_code == 400
             assert exc.value.detail == 'Invalid user credentials'
 
+    # Authenticating a deactivated moderator with correct credentials
+    def test_authenticate_deactivated_moderator(self, mocker):
+        
+        pwd = "hashed_password"
+        h_pwd = mod_service.hash_password(pwd)
+        
+        db = mocker.Mock()
+        mod = mocker.Mock(password=h_pwd, is_active=False)
+        db.query().filter().first.return_value = mod
+        
+
+        with pytest.raises(HTTPException) as exc:
+            mod_service.authenticate_mod(db, "john.doe@example.com", h_pwd)
+            
+            assert exc.value.status_code == 401
+            assert exc.value.detail == 'Deactivated account'
 
 
     # Creating a moderator with an existing email or username


### PR DESCRIPTION

## Description
This PR adds an if-guard to ensure that deactivated accounts are unable to sign-in.
​

## Motivation and Context
This fixes the problem of having to check if an account is active before performing an authenticated action
​

## How Has This Been Tested?
Added pytest case to validate that a 401 error is thrown when a deactivated account attempts to sign up.
​

## Types of changes

- [x] New feature (non-breaking change which adds functionality)      ​

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
