### PR TITLE
feat: added query parameters to GET moderators endpoint

### DIFF
--- a/api/v1/schemas/moderator.py
+++ b/api/v1/schemas/moderator.py
@@ -94,3 +94,7 @@ class ReturnModeratorDataForAdmin(CreateModeratorResponseSchema):
 
 class RetrieveModeratorsModelResponseSchema(BaseSuccessResponseSchema):
     data: list[ReturnModeratorDataForAdmin]
+
+
+class RetrieveSingleModeratorModelResponseSchema(BaseSuccessResponseSchema):
+    data: ReturnModeratorDataForAdmin

--- a/api/v1/services/moderator.py
+++ b/api/v1/services/moderator.py
@@ -61,16 +61,24 @@ class ModeratorService(Service):
         all_moderators = db.query(Moderator).all()
         return all_moderators
 
-    def fetch(self, db: Session, id: str):
+    def fetch(self, db: Session, id: str, raise_404=False):
         """Fetches a moderator by their id"""
 
         mod = db.get(Moderator, id)
+        
+        if mod is None and raise_404 is True:
+            raise self.NOT_FOUND_EXC
         return mod
 
-    def fetch_by_email(self, db: Session, email: EmailStr) -> Moderator | None:
+    def fetch_by_email(
+        self, db: Session, email: EmailStr, raise_404=False
+    ) -> Moderator | None:
         """Fetches a moderator by their email"""
 
         mod = db.query(Moderator).filter(Moderator.email == email).first()
+
+        if mod is None and raise_404 is True:
+            raise self.NOT_FOUND_EXC
         return mod
 
     def create(

--- a/tests/v1/moderator/test_retrieve_mods.py
+++ b/tests/v1/moderator/test_retrieve_mods.py
@@ -80,6 +80,74 @@ class TestRetrieveAllModerators:
         assert response.json()["data"][0]["first_name"] == mock_data[0].first_name
         assert response.json()["data"][1]["first_name"] == mock_data[1].first_name
 
+    def test_get_moderator_by_email(self, client: TestClient, mocker: MockerFixture):
+        """Test to verify response for getting moderator by email param."""
+
+        mock_data = mock_mod(first_name="Whoo?")
+
+        mock_fetch = mocker.patch.object(
+            mod_service, "fetch_by_email", return_value=mock_data
+        )
+        response = client.get(ENDPOINT_URL, params={"email": mock_data.email})
+
+        assert response.status_code == 200
+        assert response.json()["data"]["first_name"] == mock_data.first_name
+        mock_fetch.assert_called_once_with(
+            db=mocked_db, email=mock_data.email, raise_404=True
+        )
+
+    def test_get_moderator_by_id(self, client: TestClient, mocker: MockerFixture):
+        """Test to verify response for getting moderator by id param."""
+
+        mock_data = mock_mod()
+
+        mock_fetch = mocker.patch.object(mod_service, "fetch", return_value=mock_data)
+        response = client.get(ENDPOINT_URL, params={"id": mock_data.id})
+
+        assert response.status_code == 200
+        assert response.json()["data"]["first_name"] == mock_data.first_name
+        mock_fetch.assert_called_once_with(
+            db=mocked_db, id=mock_data.id, raise_404=True
+        )
+
+    def test_get_moderator_by_invalid_email_string(
+        self, client: TestClient, mocker: MockerFixture
+    ):
+        """Test to verify response for getting moderator by malformed email param."""
+
+        # mock_data = mock_mod(first_name="Whoo?")
+
+        # mock_fetch = mocker.patch.object(
+        #     mod_service, "fetch_by_email", return_value=mock_data
+        # )
+        response = client.get(ENDPOINT_URL, params={"email": "malformed-email"})
+        assert response.status_code == 422
+
+    def test_get_moderator_by_id_not_found(
+        self, client: TestClient, mocker: MockerFixture
+    ):
+        """Test to unsuccessful request for getting moderator by id param."""
+
+        mock_fetch = mocker.patch.object(mocked_db, "get", return_value=None)
+        response = client.get(ENDPOINT_URL, params={"id": "random-id"})
+
+        assert response.status_code == 404
+        assert response.json()["message"] == "Moderator not found"
+        mock_fetch.assert_called_once_with(Moderator, "random-id")
+
+    def test_get_moderator_by_email_not_found(
+        self, client: TestClient, mocker: MockerFixture
+    ):
+        """Test to unsuccessful request for getting moderator by email param."""
+
+        # mock_fetch = mocker.patch.object(mocked_db, "get", return_value=None)
+        mocked_db.query().filter().first.return_value = None
+        response = client.get(ENDPOINT_URL, params={"email": "valid@email.com"})
+        mocked_db.reset_mock()
+
+        assert response.status_code == 404
+        assert response.json()["message"] == "Moderator not found"
+
     def test_get_all_moderators_empty(self, client, mocker: MockerFixture):
         """Test to verify response for getting all moderators, even when there are
         none."""


### PR DESCRIPTION
## Description

Added optional query parameters `id` and `email` to the `GET /api/v1/moderators` endpoint.

These parameter make it easier to retrieve a single moderator resource from the backend.

The changes include:

- **Query Parameter Addition:**

  - Added `QUERY id` for passing a moderator's id.
  - Added `QUERY email` for passing a moderator's email.

- **Error Handling:**

  - Implemented checks for invalid moderator id.
  - Implemented checks for invalid moderator id.
  - Implemented checks for malformed moderator email.
  - Implemented unauthorized access checks.

- **Helper Functions:** Added utility functions and service methods to help with business logic on the backend.

## Motivation and Context

These parameters were necessary to facilitate the retrieval of a moderator resource stored on the backend.

## How Has This Been Tested?

- **Unit Tests:** Endpoint tests were added to validate the retrieval operations performed on the moderators resource.
- **Test Environment:** Tests were run using a mocked database instance to avoid interference with the dev environment.

Tests include:

- Retrive a moderator by a valid email.
- Retrive a moderator by a valid id.
- Retrive a moderator by an invalid email.
- Retrive a moderator by an invalid id.
- Retrive a moderator by a malformed email.

## Screenshots:

### Retrieve mod by email
![image](https://github.com/user-attachments/assets/e0989256-0190-444b-92eb-8a44eb7434e2)

### Retrieve mod by id
![image](https://github.com/user-attachments/assets/80004c3b-dd8a-49ed-bae7-d6a0e15792ec)

### Retrieve mod by invalid id
![image](https://github.com/user-attachments/assets/d388c25a-a159-4942-b449-130a32e9ccd4)

### Retrieve mod by malformed email
![image](https://github.com/user-attachments/assets/fe6aface-deac-47a6-84cf-b90917b0e864)

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
